### PR TITLE
本を削除した状態でバーコードを読み込んだ際に本がズレる不具合を修正

### DIFF
--- a/Login/Student/Home/StudentHome.php
+++ b/Login/Student/Home/StudentHome.php
@@ -234,19 +234,11 @@ $lentBooks = $dao->getLentNowBooks($user);
                         "ISBN": ISBN
                         //async:false //同期処理（処理がそこまで重くないプログラムのため）
                     }
-<<<<<<< HEAD
                 }).done(function(result){
                     result = parseInt(result);
                     alert(result);
                     book = (result - 1);
                     Golink(allBooks, book);
-=======
-                }).done(function(result) {
-                    book_id = (result - 1);
-                    Golink(allBooks, book_id);
-
-                }).fail(function(result) {
->>>>>>> f12721a090d6b6c6f802099a88db1dc290c03daa
                     
                     alert("お探しの本は見つかりませんでした")
                 })

--- a/Login/Student/Home/StudentHome.php
+++ b/Login/Student/Home/StudentHome.php
@@ -235,8 +235,10 @@ $lentBooks = $dao->getLentNowBooks($user);
                     //async:false //同期処理（処理がそこまで重くないプログラムのため）
                     }
                 }).done(function(result){
-                    book_id = (result - 1 );
-                    Golink(allBooks, book_id);
+                    result = parseInt(result);
+                    alert(result);
+                    book = (result - 1);
+                    Golink(allBooks, book);
                     
                 }).fail(function(result){
                     alert("お探しの本は見つかりませんでした")

--- a/Login/Student/Home/StudentHome.php
+++ b/Login/Student/Home/StudentHome.php
@@ -236,11 +236,8 @@ $lentBooks = $dao->getLentNowBooks($user);
                     }
                 }).done(function(result){
                     result = parseInt(result);
-                    alert(result);
                     book = (result - 1);
                     Golink(allBooks, book);
-                    
-                    alert("お探しの本は見つかりませんでした")
                 })
             };
         }

--- a/Test_DB/Ajax.php
+++ b/Test_DB/Ajax.php
@@ -43,7 +43,7 @@ switch($process){
         $ISBN = filter_input(INPUT_POST, 'ISBN');
         // DAOクラスをインスタンス化
         $dao = new DAO();
-        //ISBNからbook_idを取り出す処理を実行
+        //ISBNからimageを取り出す処理を実行
         echo $dao->searchISBN($ISBN);
         break;
         

--- a/Test_DB/db.php
+++ b/Test_DB/db.php
@@ -176,8 +176,18 @@ class DAO
 
     //ISBNコードからbook_idを返す関数（実装中）
     public function searchISBN($ISBN)
-        //ISBNコードから書籍検索し、該当書籍のbook_idを返す
+        //book_idの若い順に並べる（SQL8.0のみ有効）
         {
+        $sql = "SELECT *, 
+                ROW_NUMBER() OVER(ORDER BY book_id ASC) 
+                AS ROW_NUMBER_OVER 
+                FROM book
+                WHERE ISBN = :ISBN";
+
+        $stmt = $this->conn->prepare($sql);
+        $stmt->execute();
+
+        //ISBNからROW_NUMBER_OVERを取ってくる
         $sql = "SELECT *
                 FROM book
                 WHERE ISBN = :ISBN";
@@ -188,7 +198,9 @@ class DAO
         
         $result = $stmt->fetch(PDO::FETCH_ASSOC);
 
-        $result = $result['book_id'];
+        $result = $result['ROW_NUMBER_OVER'];
+
+       
 
         return $result;
         }

--- a/Test_DB/db.php
+++ b/Test_DB/db.php
@@ -177,7 +177,7 @@ class DAO
     //ISBNコードからbook_idを返す関数（実装中）
     public function searchISBN($ISBN)
         //book_idの若い順に並べる（SQL8.0のみ有効）
-        {
+    {
         $sql = "SELECT *, 
                 ROW_NUMBER() OVER(ORDER BY book_id ASC) 
                 AS ROW_NUMBER_OVER 
@@ -202,7 +202,7 @@ class DAO
        
 
         return $result;
-        }
+    }
         
 
         public function deleteProcess($book_id)
@@ -222,5 +222,33 @@ class DAO
         $stmt->execute();
 
     }
-        
+
+
+    // ログインしているユーザのクラスの先月の貸出情報を取得
+    public function getLastMonthLending($affiliation_id)
+    {
+        // 貸出履歴の取得
+        $sql = "SELECT l.lent_time, COUNT(*) as count FROM lent AS l 
+                INNER JOIN book AS b 
+                ON l.book_id = b.book_id 
+                WHERE lent_time LIKE :lent_time 
+                AND b.affiliation_id = :affiliation_id 
+                GROUP BY l.lent_time 
+                ORDER BY l.lent_time";
+
+        $stmt = $this->conn->prepare($sql);
+
+        // 先月の月を求める
+        // $lastMonth = new DateTime("-1 month");
+        $lastMonth = new DateTime();
+        $lastMonth = $lastMonth->format("Y-m");
+        $lastMonth = $lastMonth . '%';
+        $stmt->bindValue(":lent_time", $lastMonth);
+        $stmt->bindValue(":affiliation_id", $affiliation_id);
+        $stmt->execute();
+
+        $result = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        return $result;
+    }
 }

--- a/Test_DB/db.php
+++ b/Test_DB/db.php
@@ -6,7 +6,7 @@ require_once("Book.php");
 class DAO
 {
     private $user = "root";
-    private $pwd = "pathSQL";
+    private $pwd = "moku2440";
     private $dsn = "mysql:host=localhost;port=3306;dbname=library;";
     private $conn;
 
@@ -176,23 +176,17 @@ class DAO
 
     //ISBNコードからbook_idを返す関数（実装中）
     public function searchISBN($ISBN)
-<<<<<<< HEAD
         //book_idの若い順に並べる（SQL8.0のみ有効）
         {
         $sql = "SELECT *, 
                 ROW_NUMBER() OVER(ORDER BY book_id ASC) 
                 AS ROW_NUMBER_OVER 
-                FROM book
-                WHERE ISBN = :ISBN";
+                FROM book";
 
         $stmt = $this->conn->prepare($sql);
         $stmt->execute();
 
         //ISBNからROW_NUMBER_OVERを取ってくる
-=======
-    //ISBNコードから書籍検索し、該当書籍のbook_idを返す
-    {
->>>>>>> f12721a090d6b6c6f802099a88db1dc290c03daa
         $sql = "SELECT *
                 FROM book
                 WHERE ISBN = :ISBN";
@@ -200,7 +194,7 @@ class DAO
         $stmt = $this->conn->prepare($sql);
         $stmt->bindValue(":ISBN", $ISBN);
         $stmt->execute();
-
+        
         $result = $stmt->fetch(PDO::FETCH_ASSOC);
 
         $result = $result['ROW_NUMBER_OVER'];
@@ -208,51 +202,25 @@ class DAO
        
 
         return $result;
-    }
+        }
+        
 
-
-    public function deleteProcess($book_id)
-    {
+        public function deleteProcess($book_id)
+    {   
         // lentテーブルから同じbook_idのものを削除（参照制約の関係）
         $sql = "DELETE FROM lent WHERE book_id = :book_id";
 
         $stmt = $this->conn->prepare($sql);
         $stmt->bindValue(":book_id", $book_id);
         $stmt->execute();
-
+        
         // bookテーブルから同じbook_idのものを削除
         $sql = "DELETE FROM book WHERE book_id = :book_id";
-
+        
         $stmt = $this->conn->prepare($sql);
         $stmt->bindValue(":book_id", $book_id);
         $stmt->execute();
+
     }
-
-    // ログインしているユーザのクラスの先月の貸出情報を取得
-    public function getLastMonthLending($affiliation_id)
-    {
-        // 貸出履歴の取得
-        $sql = "SELECT l.lent_time, COUNT(*) as count FROM lent AS l 
-                INNER JOIN book AS b 
-                ON l.book_id = b.book_id 
-                WHERE lent_time LIKE :lent_time 
-                AND b.affiliation_id = :affiliation_id 
-                GROUP BY l.lent_time 
-                ORDER BY l.lent_time";
-
-        $stmt = $this->conn->prepare($sql);
-
-        // 先月の月を求める
-        // $lastMonth = new DateTime("-1 month");
-        $lastMonth = new DateTime();
-        $lastMonth = $lastMonth->format("Y-m");
-        $lastMonth = $lastMonth . '%';
-        $stmt->bindValue(":lent_time", $lastMonth);
-        $stmt->bindValue(":affiliation_id", $affiliation_id);
-        $stmt->execute();
-
-        $result = $stmt->fetchAll(PDO::FETCH_ASSOC);
-
-        return $result;
-    }
+        
 }

--- a/Test_DB/db.php
+++ b/Test_DB/db.php
@@ -178,17 +178,10 @@ class DAO
     public function searchISBN($ISBN)
         //book_idの若い順に並べる（SQL8.0のみ有効）
     {
-        $sql = "SELECT *, 
-                ROW_NUMBER() OVER(ORDER BY book_id ASC) 
-                AS ROW_NUMBER_OVER 
-                FROM book";
-
-        $stmt = $this->conn->prepare($sql);
-        $stmt->execute();
 
         //ISBNからROW_NUMBER_OVERを取ってくる
         $sql = "SELECT *
-                FROM book
+                FROM book2
                 WHERE ISBN = :ISBN";
 
         $stmt = $this->conn->prepare($sql);
@@ -197,7 +190,7 @@ class DAO
         
         $result = $stmt->fetch(PDO::FETCH_ASSOC);
 
-        $result = $result['ROW_NUMBER_OVER'];
+        $result = $result['num'];
 
        
 


### PR DESCRIPTION
本を削除した状態でバーコードを読み込んだ際に配列がズレて本がズレる不具合を修正
（どうしてもパスワードが変更されてしまう...ごめんなさい）